### PR TITLE
Fix formatting in platform-specific setup chapter

### DIFF
--- a/src/getting_started/platform-specific_setup.md
+++ b/src/getting_started/platform-specific_setup.md
@@ -64,7 +64,6 @@ Depending on what OS you are running, you might require an extra step or two.
     approach that suits you best we recommend searching for vulkan driver
     installation for your graphics card on your distro.
 
-
     For Fedora with AMD graphic cards:
     ```bash
     sudo dnf install vulkan vulkan-info


### PR DESCRIPTION
At the moment, the Vulkan installation commands are at an incorrect indentation level, but I think this should fix it.