### PR TITLE
Add missing build-deps. Swap "Installing Rust" and "Platform-specific Setup" order.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,8 +4,8 @@
 
 - [Why Nannou?](./why_nannou.md)
 - [Getting Started](./getting_started.md)
-    - [Installing Rust](./getting_started/installing_rust.md)
     - [Platform-specific Setup](./getting_started/platform-specific_setup.md)
+    - [Installing Rust](./getting_started/installing_rust.md)
     - [Editor Setup](./getting_started/editor_setup.md)
     - [Running Examples](./getting_started/running_examples.md)
     - [Create A Project](./getting_started/create_a_project.md)

--- a/src/getting_started/installing_rust.md
+++ b/src/getting_started/installing_rust.md
@@ -3,7 +3,9 @@
 Nannou is a library written for the [Rust programming
 language](https://www.rust-lang.org/). Thus, the first step is to install Rust!
 
-To install Rust, open up your terminal, copy the text below, paste it into your
+To install Rust on **Windows**, download and run the installer from
+[here](https://www.rust-lang.org/tools/install). If you're on **macOS** or
+**Linux**, open up your terminal, copy the text below, paste it into your
 terminal and hit enter.
 
 ```bash

--- a/src/getting_started/platform-specific_setup.md
+++ b/src/getting_started/platform-specific_setup.md
@@ -1,15 +1,19 @@
 # Platform-specific Setup
 
+Before we get started, let's make sure we have all the necessary ingredients for
+installing Rust and building nannou projects.
+
 Depending on what OS you are running, you might require an extra step or two.
 
 - **All Platforms**
 
   For now, nannou requires that you have both `python` and `cmake` installed.
-  These are required by a tool called `shaderc`. The role of this tool is to
-  compile GLSL shaders to SPIR-V so that we may run them using the system's
-  Vulkan implementation. There are a few attempts at pure-rust alternatives to
-  this tool in the works and we hope to switch to one of these in the near
-  future to avoid the need for these extra dependencies.
+  These are required by a tool called `shaderc`, a part of nannou's graphics
+  stack. The role of this tool is to compile GLSL shaders to SPIR-V so that we
+  may run them using the system's Vulkan implementation. There are a few
+  attempts at pure-rust alternatives to this tool in the works and we hope to
+  switch to one of these in the near future to avoid the need for these extra
+  dependencies.
 
 - **macOS**: Ensure that you have xcode-tools installed:
 
@@ -28,7 +32,31 @@ Depending on what OS you are running, you might require an extra step or two.
   downloading and installing the next version the next time you attempt to build
   a nannou project.
 
+- **Windows**: Install the `ninja` tool.
+
+  This tool is another required by the `shaderc` tool as mentioned under the
+  "All Platforms" section above.
+
+  1. Download the latest release of ninja from the [ninja releases
+     page](https://github.com/ninja-build/ninja/releases).
+  2. Place the `ninja.exe` file somewhere you are happy for it to stay.
+  3. Add the directory containing `ninja.exe` to your `Path` environment
+     variable if it is not already included.
+
 - **Linux**: ensure you have the following system packages installed:
+
+  - **Basic dev packages**
+
+    First make sure our basic dev packages are installed. `curl` will be
+    required by `rustup` the rust toolchain manager. `build-essentials` will be
+    required by `rustc` the rust compiler for linking. `cmake` and `python` are
+    necessary for nannou's `shaderc` dependency to build, as mentioned in the
+    "All Platforms" section above.
+
+    For Debian/Ubuntu users:
+    ```bash
+    sudo apt-get install curl build-essentials python cmake
+    ```
 
   - **alsa dev package**
 
@@ -123,10 +151,4 @@ Depending on what OS you are running, you might require an extra step or two.
     sudo pacman -S nvidia lib32-nvidia-utils
     ```
 
-- **Windows**: Install the `ninja` tool.
-
-  This tool is another required by the `shaderc` tool as mentioned under the
-  "All Platforms" section above. Installation of this tool can be a little
-  finicky so we are aiming to improve this section of the guide soon, but for
-  now, here is a link to the [ninja
-  releases](https://github.com/ninja-build/ninja/releases).
+OK, we should now be ready to install Rust!


### PR DESCRIPTION
This is @tpltnt's PR #12 with some additions and adjustments.

This also re-orders the "Getting Started" section so that "Platform-specific Setup" comes before "Installing Rust", allowing us to make sure that everything necessary for rust installation is available.

Closes #12 and nannou-org/nannou#320.