### PR TITLE
fix: Fix build-essential

### DIFF
--- a/src/getting_started/platform-specific_setup.md
+++ b/src/getting_started/platform-specific_setup.md
@@ -48,14 +48,14 @@ Depending on what OS you are running, you might require an extra step or two.
   - **Basic dev packages**
 
     First make sure our basic dev packages are installed. `curl` will be
-    required by `rustup` the rust toolchain manager. `build-essentials` will be
+    required by `rustup` the rust toolchain manager. `build-essential` will be
     required by `rustc` the rust compiler for linking. `cmake` and `python` are
     necessary for nannou's `shaderc` dependency to build, as mentioned in the
     "All Platforms" section above.
 
     For Debian/Ubuntu users:
     ```bash
-    sudo apt-get install curl build-essentials python cmake
+    sudo apt-get install curl build-essential python cmake
     ```
 
   - **alsa dev package**


### PR DESCRIPTION
I am running the command in the doc in Ubuntu 18.04:

```
$ sudo apt-get install curl build-essentials python cmake
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package build-essentials
```

I think the `build-essentials` should be `build-essential`

```
$ sudo apt-get install curl build-essential python cmake 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
build-essential is already the newest version (12.4ubuntu1).
cmake is already the newest version (3.10.2-1ubuntu2).
python is already the newest version (2.7.15~rc1-1).
curl is already the newest version (7.58.0-2ubuntu3.7).
0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
```