### PR TITLE
Add an explanation of how run additional examples

### DIFF
--- a/src/getting_started/running_examples.md
+++ b/src/getting_started/running_examples.md
@@ -24,10 +24,20 @@ cargo run --release --example simple_draw
 
 The `--release` flag means we want to build with optimisations enabled.
 
-If you are compiling nannou for the first time you will see cargo download and build all the necessary dependencies.
+The `--example` flag is a reference to the `[[examples]]` dictionary in the root
+`Cargo.toml` file. Each key references a file in the `examples/` directory, so
+to run the code at
+`examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs` you would
+run
+
+```bash
+cargo run --release --example 1_1_bouncingball_novectors
+```
+
+If you are compiling nannou for the first time you will see cargo download and
+build all the necessary dependencies.
 
 ![cargo](https://i.imgur.com/5OBNqMB.gif)
-
 
 Once the example compiles you should see the following window appear.
 

--- a/src/getting_started/running_examples.md
+++ b/src/getting_started/running_examples.md
@@ -24,9 +24,26 @@ cargo run --release --example simple_draw
 
 The `--release` flag means we want to build with optimisations enabled.
 
-The `--example` flag is a reference to the `[[examples]]` dictionary in the root
-`Cargo.toml` file. Each key references a file in the `examples/` directory, so
-to run the code at
+The value passed via the `--example` flag matches the `name` property of an
+object in the `[[examples]]` table in the root `Cargo.toml` file. The matched
+object's `path` property points to the source file to compile:
+
+```toml
+# --------------- Nannou Examples
+[[example]]
+name = "simple_draw"
+path = "examples/simple_draw.rs"
+
+# ...
+
+# --------------- Nature of Code
+# --------------- Chapter 1 Vectors
+[[example]]
+name = "1_1_bouncingball_novectors"
+path = "examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs"
+```
+
+This means that to run the code at
 `examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs` you would
 run
 


### PR DESCRIPTION
As a complete newcomer to Rust it wasn't immediately obvious to me how to run the additional examples. This PR adds a bit of context that I was missing.

My problem was that I wasn't even sure how the `--example` flag worked in the provided `simple_draw` case: was it a convention that the source file would be in the `examples` directory? Was that why the path and file extension were omitted? If so, how come running `nature_of_code/chp_01_vectors/1_1_bouncingball_novectors` gave me an error about `no example target`? Digging into the `Cargo.toml` file meant that I stumbled across the answer, but I might not have.

Any corrections gratefully received 👍 